### PR TITLE
feat : fix the repo name overflow issue

### DIFF
--- a/components/TopRepositories.tsx
+++ b/components/TopRepositories.tsx
@@ -36,7 +36,7 @@ export default function TopRepositories({ data }: { data: any }) {
                 className="flex-1 text-primary-600 dark:text-primary-400 hover:underline"
               >
                 <span className="repo-title inline-flex items-center text-primary-600 dark:text-primary-400">
-                  {repo.name}
+                {repo.name.length > 18 ? `${repo.name.substring(0, 15)}...` : repo.name}
                 </span>
               </a>
               <a 


### PR DESCRIPTION
fix the issue #4 
before 
![issue](https://github.com/user-attachments/assets/52c72c62-95bf-4ed9-a2c9-3e214bbcef25)
now 
![WhatsApp Image 2025-02-20 at 21 54 44_64f0c836](https://github.com/user-attachments/assets/90980ddb-9d25-486b-a306-631512242dd6)
